### PR TITLE
Clear online user lists when onlineSet is received

### DIFF
--- a/src/hcclient/client/client.py
+++ b/src/hcclient/client/client.py
@@ -254,6 +254,10 @@ class Client:
 
                 match received["cmd"]:
                     case "onlineSet":
+                        self.online_users.clear()
+                        self.online_users_details.clear()
+                        self.online_ignored_users.clear()
+
                         for nick in received["nicks"]:
                             self.online_users.append(nick)
 


### PR DESCRIPTION
If a subsequent `onlineSet` is received, this will append to the existing online user lists. However, this commit changes it to mirror how the hack.chat web client handles it and clears the lists.





